### PR TITLE
fix: uploaded files should have `test` flag set to `true`

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel.php
+++ b/src/Codeception/Lib/Connector/Laravel.php
@@ -477,10 +477,6 @@ class Laravel extends Client
         return $this->convertToTestFiles($files);
     }
 
-    /**
-     * @param array $files
-     * @return array
-     */
     private function convertToTestFiles(array $files): array
     {
         $filtered = [];

--- a/src/Codeception/Lib/Connector/Laravel.php
+++ b/src/Codeception/Lib/Connector/Laravel.php
@@ -471,7 +471,7 @@ class Laravel extends Client
      * @param array $files
      * @return array
      */
-    protected function filterFiles(array $files)
+    protected function filterFiles(array $files): array
     {
         $files = parent::filterFiles($files);
         return $this->convertToTestFiles($files);

--- a/src/Codeception/Lib/Connector/Laravel.php
+++ b/src/Codeception/Lib/Connector/Laravel.php
@@ -463,4 +463,36 @@ class Laravel extends Client
     {
         $this->applicationHandlers = [];
     }
+    
+    /**
+     * Make sure files are \Illuminate\Http\UploadedFile instances with the private $test property set to true.
+     * Fixes issue https://github.com/Codeception/Codeception/pull/3417.
+     *
+     * @param array $files
+     * @return array
+     */
+    protected function filterFiles(array $files)
+    {
+        $files = parent::filterFiles($files);
+        return $this->convertToTestFiles($files);
+    }
+
+    /**
+     * @param array $files
+     * @return array
+     */
+    private function convertToTestFiles(array $files): array
+    {
+        $filtered = [];
+
+        foreach ($files as $key => $value) {
+            if (is_array($value)) {
+                $filtered[$key] = $this->convertToTestFiles($value);
+            } else {
+                $filtered[$key] = UploadedFile::createFromBase($value, true);
+            }
+        }
+
+        return $filtered;
+    }
 }


### PR DESCRIPTION
The block of code fixing the issue https://github.com/Codeception/Codeception/pull/3417 was remove when moving from laravel 5 module. 

I do not know what was the reasoning behind it, but it breaks tests relying on the `test` flag being set to `true`.  

I did not add any tests as this change is not fitting your contributor's guide and it is unclear to me where to do this. 