### PR TITLE
Allow Laravel 9, improve Codeception 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         "php": "^8.0",
         "ext-json": "*",
         "codeception/lib-innerbrowser": "^2.0 | *@dev",
-        "codeception/codeception": "^5.0.0-alpha1"
+        "codeception/codeception": "^5.0.0-alpha1 | dev-5.0-interfaces"
     },
     "require-dev": {
         "codeception/module-asserts": "^2.0 | *@dev",
         "codeception/module-rest": "^2.0 | *@dev",
-        "laravel/framework": "^6.0 | ^7.0 | ^8.0",
+        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0",
         "vlucas/phpdotenv": "^3.6 | ^4.2 | ^5.3"
     },
     "autoload": {

--- a/src/Codeception/Module/Laravel.php
+++ b/src/Codeception/Module/Laravel.php
@@ -152,7 +152,7 @@ class Laravel extends Framework implements ActiveRecord, PartedModule
     /**
      * @var array
      */
-    public $config = [];
+    public array $config = [];
 
     public function __construct(ModuleContainer $moduleContainer, ?array $config = null)
     {


### PR DESCRIPTION
This small PR adds Laravel 9 and php 8.1  compatibility