### PR TITLE
Use the testing environment file specified in a suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         "php": "^8.0",
         "ext-json": "*",
         "codeception/lib-innerbrowser": "^3.1",
-        "codeception/codeception": "^5.0.0-RC2"
+        "codeception/codeception": "^5.0.0-RC2",
+        "vlucas/phpdotenv": "^5.3"
     },
     "require-dev": {
         "codeception/module-asserts": "^3.0",
         "codeception/module-rest": "^3.1",
-        "laravel/framework": "^8.0",
-        "vlucas/phpdotenv": "^5.3"
+        "laravel/framework": "^8.0"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/src/Codeception/Lib/Connector/Laravel.php
+++ b/src/Codeception/Lib/Connector/Laravel.php
@@ -9,6 +9,7 @@ use Codeception\Lib\Connector\Laravel\ExceptionHandlerDecorator as LaravelExcept
 use Codeception\Lib\Connector\Laravel6\ExceptionHandlerDecorator as Laravel6ExceptionHandlerDecorator;
 use Codeception\Module\Laravel as LaravelModule;
 use Codeception\Stub;
+use Dotenv\Dotenv;
 use Exception;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -186,7 +187,12 @@ class Laravel extends Client
     {
         /** @var AppContract $app */
         $app = require $this->module->config['bootstrap_file'];
-        $app->loadEnvironmentFrom($this->module->config['environment_file']);
+        if ($this->module->config['environment_file'] !== '.env') {
+            Dotenv::createMutable(
+                $app->basePath(),
+                $this->module->config['environment_file']
+            )->load();
+        }
         $app->instance('request', new Request());
 
         return $app;


### PR DESCRIPTION
Fixed #20 

The Laravel creates an immutable environment repository instance [`\Dotenv\Repository\RepositoryInterface`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/Env.php#L61). The instance is [`RepositoryBuilder`](https://github.com/vlucas/phpdotenv/blob/master/src/Repository/RepositoryBuilder.php#L237) from the package [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv).
When the Laravel tries change ENV-values to the .env-file from the Codeception, the immutable RepositoryBuilder [does not](https://github.com/vlucas/phpdotenv/blob/v4.1.7/src/Repository/AbstractRepository.php#L80).