### PR TITLE
fix: use the request object resolved from the app container as parameter to kernel's terminate method call

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel.php
+++ b/src/Codeception/Lib/Connector/Laravel.php
@@ -111,7 +111,7 @@ class Laravel extends Client
 
         $request = Request::createFromBase($request);
         $response = $this->kernel->handle($request);
-        $this->getHttpKernel()->terminate($request, $response);
+        $this->getHttpKernel()->terminate($this->app['request'], $response);
 
         return $response;
     }


### PR DESCRIPTION
Closes #28 

Link to test PR: tbc