### PR TITLE
Add laravel v12 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10, 11]
+        laravel: [10, 11, 12]
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "codeception/module-asserts": "^3.0",
         "codeception/module-rest": "^3.3",
-        "laravel/framework": "^10.0 | ^11.0"
+        "laravel/framework": "^10.0 | ^11.0 | ^12.0"
     },
     "autoload": {
         "classmap": ["src/"]


### PR DESCRIPTION
This MR updates our CI to include testing against Laravel 12. It makes the CI matrix aware of the new framework version.